### PR TITLE
Just one more line to make it JSON-friendly

### DIFF
--- a/lib/boolean.pm
+++ b/lib/boolean.pm
@@ -79,6 +79,8 @@ sub truth {
     &Internals::SvREADONLY( \ !!1, 1);
 }
 
+sub TO_JSON() { ${$_[0]} ? \1 : \ 0 }
+
 1;
 
 =encoding utf8

--- a/t/json.t
+++ b/t/json.t
@@ -1,0 +1,11 @@
+use Test::More tests => 2;
+use boolean -truth;
+my $HAVE_JSON = eval { require JSON };
+SKIP: {
+    skip "JSON is missing", 2 unless $HAVE_JSON;
+    eval{
+        my $json = JSON->new->convert_blessed();
+        is($json->encode({false => (0 == 1)}), '{"false":false}');
+        is($json->encode({true  => (1 == 1)}), '{"true":true}');
+    }
+};


### PR DESCRIPTION
ingy,

It's rather unfortunate JSON(::XS)? does not regard boolean.pm.
It's fortunate we need a single line to fix that.

``` perl
sub TO_JSON() { ${$_[0]} ? \1 : \ 0 }
```

Would you merge so the rest of us can save the line?

Dan the Fan of Yours
