### PR TITLE
Remove Readonly to fix TO_JSON with JSON::XS

### DIFF
--- a/lib/boolean.pm
+++ b/lib/boolean.pm
@@ -27,17 +27,10 @@ sub import {
 my ($true_val, $false_val, $bool_vals);
 
 BEGIN {
-    my $have_readonly = eval { require Readonly };
-
     my $t = 1;
     my $f = 0;
     $true  = do {bless \$t, 'boolean'};
     $false = do {bless \$f, 'boolean'};
-
-    if ( $have_readonly ) {
-        Readonly::Scalar($t => $t);
-        Readonly::Scalar($f => $f);
-    }
 
     $true_val  = overload::StrVal($true);
     $false_val = overload::StrVal($false);

--- a/test/boolean.t
+++ b/test/boolean.t
@@ -1,4 +1,4 @@
-use Test::More tests => 65;
+use Test::More tests => 61;
 use strict;
 use lib 'lib';
 
@@ -120,16 +120,6 @@ eval 'true(1)'; ok $@, "Can't pass values to true/false";
 eval 'true(@main::array)'; ok $@, "Can't pass values to true/false";
 eval 'true(())'; ok $@, "Can't pass values to true/false";
 eval 'false(undef)'; ok $@, "Can't pass values to true/false";
-
-# Check that true is immutable
-SKIP: {
-    skip "Need Readonly to make truth immutable", 4 if !eval { require Readonly };
-    for my $bool (true, false) {
-        my $truthiness = !!$bool;
-        ok !eval { $$bool = 0; 1 }, "truth is forever";
-        is $bool, $truthiness, "imutable";
-    }
-}
 
 ok true->isTrue, "true isTrue";
 ok false->isFalse, "false isFalse";

--- a/test/json.t
+++ b/test/json.t
@@ -12,5 +12,6 @@ SKIP: {
             'JSON true works');
         is(ref(boolean::TO_JSON(true)), 'SCALAR',
             'Make sure we can call boolean::TO_JSON($b)');
-    }
+    };
+    diag "$@" if $@;
 };


### PR DESCRIPTION
JSON::XS is incompatible with the use of Readonly and causes
fatal exceptions trying to serialize.

Fixes #5 and partially addresses #6.

