### PR TITLE
fix erroneously italicized word in docs

### DIFF
--- a/ReadMe.pod
+++ b/ReadMe.pod
@@ -61,7 +61,7 @@ include: Hash, Array, String, Number, Null and Boolean. Perl lacks native
 Boolean support.
 
 Data interchange modules like YAML and JSON can now C<use boolean> to
-encodeI<decode>roundtrip Boolean values.
+encode/decode/roundtrip Boolean values.
 
 =head1 Functions
 

--- a/doc/boolean.swim
+++ b/doc/boolean.swim
@@ -44,7 +44,7 @@ include: Hash, Array, String, Number, Null and Boolean. Perl lacks native
 Boolean support.
 
 Data interchange modules like YAML and JSON can now `use boolean` to
-encode/decode/roundtrip Boolean values.
+encode\/decode\/roundtrip Boolean values.
 
 = Functions
 


### PR DESCRIPTION
The Markdown `//` construct was being inappropriately applied to a list
of values being separated by `/`
